### PR TITLE
[Rev. 1] Simplify Concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,27 +42,28 @@ Measurements are performed on low-middle laptop with following characteristics:
 | **RAM** | 16.0 GB (14.9 GB usable)                                   |
 | **SSD** | NVMe____WDC_PC_SN530_SDB7                                  |
 | **OS** | Windows 11 (ver. 22H2)                                     |
+| **JDK**  | graalvm-ce-java17@22.3.1 |
 
 #### Example of measurements
 
-Handling of provided file with size of `120GB` takes about `6.5 min` in average.
+Handling of provided file with size of `120GB` takes about `5 min` in average.
 
 ```shell
-PS D:\ip_addresses> Measure-Command { java -jar C:\Users\unrea\IdeaProjects\ip-counter\target\ip-counter.jar D:\ip_addresses\ip_addresses | Out-Host }
+PS C:\Users\unrea> Measure-Command { java -jar C:\Users\unrea\IdeaProjects\ip-counter\target\ip-counter.jar D:\ip_addresses\ip_addresses | Out-Host }
 1000000000
 
 
 Days              : 0
 Hours             : 0
-Minutes           : 6
-Seconds           : 19
-Milliseconds      : 925
-Ticks             : 3799251176
-TotalDays         : 0.0043972814537037
-TotalHours        : 0.105534754888889
-TotalMinutes      : 6.33208529333333
-TotalSeconds      : 379.9251176
-TotalMilliseconds : 379925.1176
+Minutes           : 5
+Seconds           : 7
+Milliseconds      : 74
+Ticks             : 3070748625
+TotalDays         : 0.00355410720486111
+TotalHours        : 0.0852985729166667
+TotalMinutes      : 5.117914375
+TotalSeconds      : 307.0748625
+TotalMilliseconds : 307074.8625
 ```
 
 

--- a/src/main/java/com/ecwid/dev/ipcounter/FileUniqueIpCounter.java
+++ b/src/main/java/com/ecwid/dev/ipcounter/FileUniqueIpCounter.java
@@ -8,7 +8,7 @@ import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import java.util.concurrent.ExecutionException;
+import java.util.concurrent.CountDownLatch;
 
 final class FileUniqueIpCounter implements Counter {
     private final Path p;
@@ -19,14 +19,16 @@ final class FileUniqueIpCounter implements Counter {
 
     @Override
     public long count() {
-        try (FileChannel fileChannel = (FileChannel) Files.newByteChannel(
+        try (FileChannel fc = (FileChannel) Files.newByteChannel(
                 p, StandardOpenOption.READ)) {
-            IntSet ipSet = IntSet.withCapacity(fileChannel.size() / ChunkIterator.IP_RECORD_BYTES + 1);
-            IteratorPublisher<ByteBuffer> submitablePublisher = new IteratorPublisher<>(() -> new ChunkIterator(fileChannel));
-            submitablePublisher.subscribe(new IpScanByteBufferSubscriber(ipSet::add));
-            submitablePublisher.block();
+            IntSet ipSet = IntSet.withCapacity(fc.size() / ChunkIterator.IP_RECORD_BYTES + 1);
+            CountDownLatch latch = new CountDownLatch(1);
+            IteratorPublisher<ByteBuffer> chunkPublisher = new IteratorPublisher<>(() -> new ChunkIterator(fc));
+            chunkPublisher.doFinally(latch::countDown);
+            chunkPublisher.subscribe(new IpScanByteBufferSubscriber(ipSet::add));
+            latch.await();
             return ipSet.size();
-        } catch (IOException | ExecutionException e) {
+        } catch (IOException e) {
             throw new IllegalStateException(e);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();

--- a/src/main/java/com/ecwid/dev/ipcounter/IpScanByteBufferSubscriber.java
+++ b/src/main/java/com/ecwid/dev/ipcounter/IpScanByteBufferSubscriber.java
@@ -7,7 +7,7 @@ import java.util.function.IntConsumer;
 
 final class IpScanByteBufferSubscriber implements Flow.Subscriber<ByteBuffer> {
     private static final char DOT = '.';
-    private static final long BUFFER_SIZE = 8;
+    private static final long BUFFER_SIZE = Runtime.getRuntime().availableProcessors();
     private final AtomicLong buffered = new AtomicLong();
     public static final int LAST_SEGMENT = 3;
 

--- a/src/main/java/com/ecwid/dev/ipcounter/IpScanByteBufferSubscriber.java
+++ b/src/main/java/com/ecwid/dev/ipcounter/IpScanByteBufferSubscriber.java
@@ -7,7 +7,7 @@ import java.util.function.IntConsumer;
 
 final class IpScanByteBufferSubscriber implements Flow.Subscriber<ByteBuffer> {
     private static final char DOT = '.';
-    private static final long BUFFER_SIZE = Runtime.getRuntime().availableProcessors();
+    private static final long BUFFER_SIZE = 8;
     private final AtomicLong buffered = new AtomicLong();
     public static final int LAST_SEGMENT = 3;
 

--- a/src/main/java/com/ecwid/dev/ipcounter/IpScanByteBufferSubscriber.java
+++ b/src/main/java/com/ecwid/dev/ipcounter/IpScanByteBufferSubscriber.java
@@ -7,7 +7,8 @@ import java.util.function.IntConsumer;
 
 final class IpScanByteBufferSubscriber implements Flow.Subscriber<ByteBuffer> {
     private static final char DOT = '.';
-    private static final long BUFFER_SIZE = 8;
+    private static final long BUFFER_SIZE = Runtime.getRuntime().availableProcessors();
+    public static final int SEGMENT_BIT_SIZE = 8;
     private final AtomicLong buffered = new AtomicLong();
     public static final int LAST_SEGMENT = 3;
 
@@ -53,12 +54,12 @@ final class IpScanByteBufferSubscriber implements Flow.Subscriber<ByteBuffer> {
                 curSegment = curSegment * 10 + d;
             } else {
                 if (c == DOT) {
-                    curIp |= (curSegment << (BUFFER_SIZE * segmentNumber));
+                    curIp |= (curSegment << (SEGMENT_BIT_SIZE * segmentNumber));
                     curSegment = 0;
                     segmentNumber++;
                 } else {
                     if (segmentNumber == LAST_SEGMENT) {
-                        curIp |= (curSegment << (BUFFER_SIZE * segmentNumber));
+                        curIp |= (curSegment << (SEGMENT_BIT_SIZE * segmentNumber));
                         ipConsumer.accept(curIp);
                         curSegment = 0;
                         segmentNumber = 0;

--- a/src/main/java/com/ecwid/dev/ipcounter/IteratorPublisher.java
+++ b/src/main/java/com/ecwid/dev/ipcounter/IteratorPublisher.java
@@ -1,43 +1,67 @@
 package com.ecwid.dev.ipcounter;
 
-import java.util.Deque;
 import java.util.Iterator;
-import java.util.concurrent.ConcurrentLinkedDeque;
-import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Flow;
-import java.util.concurrent.ForkJoinPool;
-import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
 class IteratorPublisher<T> implements Flow.Publisher<T> {
-    private static final ExecutorService EXECUTOR_SERVICE = ForkJoinPool.commonPool();
+    private static final int NUM_CORES = Runtime.getRuntime().availableProcessors();
+    private static final ExecutorService EXECUTOR_SERVICE = parallelPool();
+
+    private static ThreadPoolExecutor parallelPool() {
+        ThreadFactory threadFactory = new NamedThreadFactory("iterator-publisher-thread");
+        ArrayBlockingQueue<Runnable> workQueue = new ArrayBlockingQueue<>(NUM_CORES * 2);
+        return new ThreadPoolExecutor(NUM_CORES, NUM_CORES, 60, TimeUnit.SECONDS, workQueue, threadFactory);
+    }
+
     private final Supplier<Iterator<T>> iteratorSupplier;
-    private final Deque<Future<?>> activeTasks = new ConcurrentLinkedDeque<>();
-    private boolean subscribed = false;
+    private final AtomicBoolean subscribed = new AtomicBoolean();
+    private Runnable finalAction;
 
     IteratorPublisher(Supplier<Iterator<T>> iteratorSupplier) {
         this.iteratorSupplier = iteratorSupplier;
     }
 
     @Override
-    public synchronized void subscribe(Flow.Subscriber<? super T> subscriber) {
-        if (!subscribed) {
+    public void subscribe(Flow.Subscriber<? super T> subscriber) {
+        if (!subscribed.getAndSet(true)) {
             IteratorSubscription<T> subscription = new IteratorSubscription<>(iteratorSupplier.get(), this, subscriber, EXECUTOR_SERVICE);
             subscriber.onSubscribe(subscription);
-            this.subscribed = true;
         } else {
             throw new IllegalStateException("Only one subscription is possible");
         }
     }
 
-    public synchronized void block() throws InterruptedException, ExecutionException {
-        while (!activeTasks.isEmpty()) {
-            activeTasks.removeFirst().get();
+    public void doFinally(Runnable runnable) {
+        this.finalAction = runnable;
+    }
+
+    void doFinally() {
+        if (finalAction != null) {
+            finalAction.run();
         }
     }
 
-    public void addTask(Future<?> task) {
-        activeTasks.addLast(task);
+    private static final class NamedThreadFactory implements ThreadFactory {
+        private final AtomicInteger count = new AtomicInteger();
+        private final String prefix;
+
+        private NamedThreadFactory(String prefix) {
+            this.prefix = prefix;
+        }
+
+        @Override
+        public Thread newThread(Runnable r) {
+            Thread thread = new Thread(r, prefix + "-" + count.getAndIncrement());
+            thread.setDaemon(true);
+            return thread;
+        }
     }
 }

--- a/src/main/java/com/ecwid/dev/ipcounter/IteratorPublisher.java
+++ b/src/main/java/com/ecwid/dev/ipcounter/IteratorPublisher.java
@@ -1,9 +1,10 @@
 package com.ecwid.dev.ipcounter;
 
 import java.util.Iterator;
-import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Flow;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -17,7 +18,7 @@ class IteratorPublisher<T> implements Flow.Publisher<T> {
 
     private static ThreadPoolExecutor parallelPool() {
         ThreadFactory threadFactory = new NamedThreadFactory("iterator-publisher-thread");
-        ArrayBlockingQueue<Runnable> workQueue = new ArrayBlockingQueue<>(NUM_CORES * 2);
+        BlockingQueue<Runnable> workQueue = new LinkedBlockingQueue<>();
         return new ThreadPoolExecutor(NUM_CORES, NUM_CORES, 60, TimeUnit.SECONDS, workQueue, threadFactory);
     }
 

--- a/src/main/java/com/ecwid/dev/ipcounter/IteratorSubscription.java
+++ b/src/main/java/com/ecwid/dev/ipcounter/IteratorSubscription.java
@@ -29,7 +29,7 @@ class IteratorSubscription<T> implements Flow.Subscription {
     }
 
     @Override
-    public void request(long n) {
+    public synchronized void request(long n) {
         if (n < 0) {
             cancel();
             throw new IllegalArgumentException();
@@ -55,7 +55,7 @@ class IteratorSubscription<T> implements Flow.Subscription {
     }
 
     @Override
-    public void cancel() {
+    public synchronized void cancel() {
         if (!isTerminated.getAndSet(true)) {
             for (Future<?> task : tasks) {
                 if (!task.isDone() && !task.isCancelled()) {

--- a/src/main/java/com/ecwid/dev/ipcounter/IteratorSubscription.java
+++ b/src/main/java/com/ecwid/dev/ipcounter/IteratorSubscription.java
@@ -1,20 +1,24 @@
 package com.ecwid.dev.ipcounter;
 
-import java.util.ArrayDeque;
-import java.util.Deque;
 import java.util.Iterator;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Flow;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
 class IteratorSubscription<T> implements Flow.Subscription {
     private final Iterator<T> iterator;
     private final IteratorPublisher<? super T> publisher;
     private final Flow.Subscriber<? super T> subscriber;
     private final ExecutorService executorService;
-    private final Deque<Future<?>> tasks = new ArrayDeque<>();
+    private final Set<Future<?>> tasks = ConcurrentHashMap.newKeySet();
     private final AtomicBoolean isTerminated = new AtomicBoolean();
+
+    private final AtomicLong leftTasks = new AtomicLong();
 
     IteratorSubscription(Iterator<T> iterator, IteratorPublisher<? super T> publisher,
                          Flow.Subscriber<? super T> subscriber, ExecutorService executorService) {
@@ -25,7 +29,7 @@ class IteratorSubscription<T> implements Flow.Subscription {
     }
 
     @Override
-    public synchronized void request(long n) {
+    public void request(long n) {
         if (n < 0) {
             cancel();
             throw new IllegalArgumentException();
@@ -36,23 +40,27 @@ class IteratorSubscription<T> implements Flow.Subscription {
                 break;
             }
             T next = iterator.next();
-            Future<?> task = executorService.submit(() -> subscriber.onNext(next));
-            publisher.addTask(task);
-            tasks.addLast(task);
+            leftTasks.incrementAndGet();
+            CompletableFuture<Void> task = CompletableFuture.runAsync(() -> subscriber.onNext(next), executorService);
+            tasks.add(task);
+            task.thenRun(() -> {
+                tasks.removeIf(Future::isDone);
+                if (leftTasks.decrementAndGet() == 0 && !iterator.hasNext()) {
+                    subscriber.onComplete();
+                    publisher.doFinally();
+                }
+            });
             i++;
-        }
-
-        if (!iterator.hasNext()) {
-            subscriber.onComplete();
         }
     }
 
     @Override
     public void cancel() {
-        isTerminated.set(true);
-        for (Future<?> task : tasks) {
-            if (!task.isDone() && !task.isCancelled()) {
-                task.cancel(true);
+        if (!isTerminated.getAndSet(true)) {
+            for (Future<?> task : tasks) {
+                if (!task.isDone() && !task.isCancelled()) {
+                    task.cancel(true);
+                }
             }
         }
     }

--- a/src/main/java/com/ecwid/dev/ipcounter/intset/BigIntSet.java
+++ b/src/main/java/com/ecwid/dev/ipcounter/intset/BigIntSet.java
@@ -26,7 +26,7 @@ class BigIntSet implements IntSet {
     public synchronized long size() {
         return IntStream.range(0, storage.length())
                 .parallel()
-                .map(i -> Integer.bitCount(storage.get(i)))
+                .mapToLong(i -> Integer.bitCount(storage.get(i)))
                 .sum();
     }
 }


### PR DESCRIPTION
- test on the latest LTS jdk
- fixed long size of big int set
- custom thread pool for the publisher
- update performance results